### PR TITLE
fix: 자잘한 수정

### DIFF
--- a/Gwan-fe/src/api/axios.js
+++ b/Gwan-fe/src/api/axios.js
@@ -30,21 +30,6 @@ const processQueue = (error, token = null) => {
     failedQueue = [];
 };
 
-// 요청 인터셉터 (요청 전 처리)
-instance.interceptors.request.use(
-    (config) => {
-        // 요청 로그 출력
-        console.log('[AXIOS REQUEST]', {
-            url: config.url,
-            method: config.method,
-            data: config.data,
-            params: config.params,
-            headers: config.headers
-        });
-        return config;
-    },
-    (error) => Promise.reject(error)
-);
 
 // 응답 인터셉터 (에러 응답 처리 등)
 instance.interceptors.response.use(

--- a/Gwan-fe/src/components/admin/UserManage.vue
+++ b/Gwan-fe/src/components/admin/UserManage.vue
@@ -109,7 +109,6 @@
             <label for="editUserRole">역할</label>
             <select id="editUserRole" v-model="editingUser.role">
               <option value="GENERAL">일반 사용자</option>
-              <option value="ADVISOR">처방사</option>
               <option value="PRESCRIBER">처방사</option>
               <option value="ADMIN">관리자</option>
             </select>

--- a/Gwan-fe/src/components/exercise/ExerciseSearchBar.vue
+++ b/Gwan-fe/src/components/exercise/ExerciseSearchBar.vue
@@ -21,7 +21,7 @@
       <div class="col-md-6">
         <div class="d-flex gap-2">
           <select class="form-select" v-model="selectedSort" @change="handleSort">
-            <option value="">정렬 방식</option>
+            <option value="">최신 순</option>
             <option value="likes">좋아요 순</option>
           </select>
           <select class="form-select" v-model="selectedTarget" @change="handleTarget">

--- a/Gwan-fe/src/views/AdminManagement.vue
+++ b/Gwan-fe/src/views/AdminManagement.vue
@@ -71,7 +71,7 @@
             <input 
               type="text" 
               class="form-control" 
-              placeholder="사용자 이름, 이메일로 검색..."
+              placeholder="닉네임으로 검색"
               v-model="searchQuery"
               @input="handleSearch"
             />


### PR DESCRIPTION
This pull request includes several updates to the `Gwan-fe` project, focusing on cleaning up unused logging, refining user-facing text, and improving consistency across components. Below are the most significant changes grouped by theme:

### Codebase Cleanup:
* Removed the request interceptor that logged Axios requests in `Gwan-fe/src/api/axios.js`, likely to reduce unnecessary console output and improve performance.

### User Interface Improvements:
* Updated the placeholder text in the search input field of `AdminManagement.vue` from "사용자 이름, 이메일로 검색..." to "닉네임으로 검색" to clarify the search functionality.
* Changed the default option text in the sort dropdown of `ExerciseSearchBar.vue` from "정렬 방식" to "최신 순" to provide a more descriptive and user-friendly label.

### Consistency in Terminology:
* Replaced the `ADVISOR` role option with `PRESCRIBER` in the user role dropdown of `UserManage.vue` to standardize role terminology.